### PR TITLE
Readme URL references updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 hawk
 ====
 
-This is the Java implementation of the [Hawk](/hueniverse/hawk) protocol.  It attempts to provide packages for generic client and server functionality, along with specific implementations for popular Java products.
+This is the Java implementation of the [Hawk](https://github.com/hueniverse/hawk) protocol.  It attempts to provide packages for generic client and server functionality, along with specific implementations for popular Java products.
 
 The current version of the Hawk protocol supported is 1.0.  However note that this implementation does not support the `Server-Authorization` response header at this time.
 
@@ -12,7 +12,7 @@ Details of how to use Hawk in your Java project are available at the main Hawk s
 
 Comments and Suggestions
 ========================
-The Hawk libraries will attempt to keep up-to-date with [the main release of Hawk](/hueniverse/hawk).  If you have any comments or suggestions on the protocol them please raise them there.  If you have any comments or suggestions on this Java implementation then please raise them here.
+The Hawk libraries will attempt to keep up-to-date with [the main release of Hawk](https://github.com/hueniverse/hawk).  If you have any comments or suggestions on the protocol them please raise them there.  If you have any comments or suggestions on this Java implementation then please raise them here.
 
 Copyright and License
 ======================


### PR DESCRIPTION
For some reason, github is failing at url references to the official hawk repository
