### PR TITLE
Support time-skew fixes in HawkClient

### DIFF
--- a/hawk-core/src/main/java/com/wealdtech/hawk/HawkClient.java
+++ b/hawk-core/src/main/java/com/wealdtech/hawk/HawkClient.java
@@ -54,6 +54,31 @@ public final class HawkClient implements Comparable<HawkClient>
   }
 
   /**
+   * Adjust the client to handle clock skew from server clock.
+   * <p/>
+   * Calculate the time-skew between the client and server, for any future
+   * request.<br/>
+   * This can handle clock skew in either the client or the server, or
+   * any timezone mis-configuration.<br/>
+   * Just call this method any time (or any number of times) after receiving
+   * a response from the server.<br/>
+   * This can be either successful or error response.
+   * <p/>
+   * Example:
+   * <pre>
+   *
+   *     URLConnection conn;
+   *     ...
+   *     //send request, receive anything.
+   *     if ( conn.getDate()!=0 ) hawkClient.setServerDate(conn.getDate());
+   * </pre>
+   * @param date the current server date, as was received from the server.
+   */
+  public void setServerDate(long date) {
+    mTimeSkew = date - System.currentTimeMillis();
+  }
+
+  /**
    * Generate the value for the Hawk authorization header.
    *
    * @param uri the URI for the request
@@ -72,7 +97,7 @@ public final class HawkClient implements Comparable<HawkClient>
                                             final String app,
                                             final String dlg)
   {
-    long timestamp = System.currentTimeMillis() / Hawk.MILLISECONDS_IN_SECONDS;
+    long timestamp = (System.currentTimeMillis() + mTimeSkew) / Hawk.MILLISECONDS_IN_SECONDS;
     final String nonce = StringUtils.generateRandomString(6);
     final String mac = Hawk.calculateMAC(this.credentials, Hawk.AuthType.HEADER, timestamp, uri, nonce, method, hash, ext, app, dlg);
 


### PR DESCRIPTION
added HawkClient.setServerDate(), to calculate current time-skew from
server's last known date.

As per hawk protocol: https://github.com/hueniverse/hawk/blob/master/README.md#replay-protection

> There is no expectation that the client will adjust its system clock to match the server (in fact, this would be a potential attack vector). Instead, the client only uses the server's time to calculate an offset used only for communications with that particular server. The protocol rewards clients with synchronized clocks by reducing the number of round trips required to authenticate the first request.

