### PR TITLE
Fix sonatypePassword in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
         ext.sonatypeUsername = ''
     }
     if (!project.hasProperty('sonatypePassword')) {
-        sonatypePassword = ''
+        ext.sonatypePassword = ''
     }
     uploadArchives {
         repositories {


### PR DESCRIPTION
This omission was preventing unit tests from starting. I don't know if this is the 100% correct fix, but it allowed me to run the tests.
