### PR TITLE
Define the mTimeSkew member variable for the Client

### DIFF
--- a/hawk-core/src/main/java/com/wealdtech/hawk/HawkClient.java
+++ b/hawk-core/src/main/java/com/wealdtech/hawk/HawkClient.java
@@ -30,6 +30,7 @@ public final class HawkClient implements Comparable<HawkClient>
 {
   private final HawkClientConfiguration configuration;
   private final HawkCredentials credentials;
+  private Long mTimeSkew;
 
   @Inject
   private HawkClient(final HawkClientConfiguration configuration,


### PR DESCRIPTION
I'm not sure how this was overlooked. Tests did not pass until I defined this member variable.  Let me know if it's appropriate to use `final` here and I'll add that.
