### PR TITLE
Add calculateBodyHash() to replace calculateBodyMac()

### DIFF
--- a/hawk-core/src/main/java/com/wealdtech/hawk/HawkCredentials.java
+++ b/hawk-core/src/main/java/com/wealdtech/hawk/HawkCredentials.java
@@ -74,6 +74,11 @@ public final class HawkCredentials implements Comparable<HawkCredentials>
                                                                                         .put(Algorithm.SHA256, "HmacSHA256")
                                                                                         .build();
 
+  private static final ImmutableMap<Algorithm, String> DIGESTALGORITHMS = new ImmutableMap.Builder<Algorithm, String>()
+                                                                                        .put(Algorithm.SHA1, "SHA-1")
+                                                                                        .put(Algorithm.SHA256, "SHA-256")
+                                                                                        .build();
+
   private HawkCredentials(final String keyId, final String key, final Algorithm algorithm)
   {
     this.keyId = keyId;
@@ -125,6 +130,16 @@ public final class HawkCredentials implements Comparable<HawkCredentials>
   public Algorithm getAlgorithm()
   {
     return this.algorithm;
+  }
+
+  /**
+   * Obtain the algorithm used to calculate the MAC
+   *
+   * @return the algorithm used to calculate the MAC
+   */
+  public String getDigestAlgorithm()
+  {
+    return DIGESTALGORITHMS.get(this.algorithm);
   }
 
   /**

--- a/hawk-core/src/test/java/test/com/wealdtech/hawk/HawkTest.java
+++ b/hawk-core/src/test/java/test/com/wealdtech/hawk/HawkTest.java
@@ -102,6 +102,17 @@ public class HawkTest
   }
 
   @Test
+  public void testBodyHash() throws Exception
+  {
+    // Ensure that the body hash gives the correct result
+    // This validates the example provided at https://github.com/hueniverse/hawk#payload-validation
+    final HawkCredentials testCredentials = new HawkCredentials.Builder().keyId("test").key("mysecretkey").algorithm(Algorithm.SHA256).build();
+    final String contentType = "text/plain";
+    String testhash1 = Hawk.calculateBodyHash(testCredentials, contentType, "Thank you for flying Hawk");
+    assertEquals(testhash1, "Yi9LfIIFRtBEPt74PVmbTF/xVAwPn7ub15ePICfgnuY=");
+  }
+
+  @Test
   public void testBewitValidation1() throws Exception
   {
     try


### PR DESCRIPTION
The content payload hash should not be dependent on the user's credentials. It's a simple message digest.

This is just the first step in remedying the situation. The rest of the Client and Server code and the tests should be updated to reflect the change.

This is a breaking change that should be messaged out to users of the library. Without it though, clients using this library cannot communicate to servers running other implementations of the server code (and vice versa).
