### PR TITLE
Added support for binary Hawk keys.

### DIFF
--- a/hawk-core/src/main/java/com/wealdtech/hawk/Hawk.java
+++ b/hawk-core/src/main/java/com/wealdtech/hawk/Hawk.java
@@ -254,7 +254,7 @@ public class Hawk
       Mac mac = Mac.getInstance(credentials.getJavaAlgorithm());
       try
       {
-        mac.init(new SecretKeySpec(credentials.getKey().getBytes("UTF-8"), credentials.getJavaAlgorithm()));
+        mac.init(new SecretKeySpec(credentials.getKey(), credentials.getJavaAlgorithm()));
         return BaseEncoding.base64().encode(mac.doFinal(text.getBytes("UTF-8")));
       }
       catch (UnsupportedEncodingException uee)

--- a/hawk-core/src/main/java/com/wealdtech/hawk/HawkCredentials.java
+++ b/hawk-core/src/main/java/com/wealdtech/hawk/HawkCredentials.java
@@ -19,6 +19,7 @@ package com.wealdtech.hawk;
 import static com.wealdtech.Preconditions.*;
 
 import java.util.Locale;
+import java.nio.charset.Charset;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -66,7 +67,7 @@ public final class HawkCredentials implements Comparable<HawkCredentials>
   }
 
   private final String keyId;
-  private final String key;
+  private final byte[] key;
   private final Algorithm algorithm;
 
   private static final ImmutableMap<Algorithm, String> JAVAALGORITHMS = new ImmutableMap.Builder<Algorithm, String>()
@@ -74,7 +75,10 @@ public final class HawkCredentials implements Comparable<HawkCredentials>
                                                                                         .put(Algorithm.SHA256, "HmacSHA256")
                                                                                         .build();
 
-  private HawkCredentials(final String keyId, final String key, final Algorithm algorithm)
+  private static final Charset utf8 = Charset.forName("UTF-8");
+  private static final Charset latin1 = Charset.forName("ISO-8859-1");
+
+  private HawkCredentials(final String keyId, final byte[] key, final Algorithm algorithm)
   {
     this.keyId = keyId;
     this.key = key;
@@ -109,10 +113,10 @@ public final class HawkCredentials implements Comparable<HawkCredentials>
   /**
    * Obtain the key.
    *
-   * @return the Key ID. Note that the key ID is a shared secret, and should be
+   * @return the Key. Note that the key is a shared secret, and should be
    *         protected accordingly
    */
-  public String getKey()
+  public byte[] getKey()
   {
     return this.key;
   }
@@ -144,7 +148,7 @@ public final class HawkCredentials implements Comparable<HawkCredentials>
   {
     return Objects.toStringHelper(this)
                   .add("keyId", this.getKeyId())
-                  .add("key", this.getKey())
+                  .add("key", java.util.Arrays.toString(this.getKey()))
                   .add("algorithm", this.getAlgorithm())
                   .toString();
   }
@@ -166,7 +170,7 @@ public final class HawkCredentials implements Comparable<HawkCredentials>
   {
     return ComparisonChain.start()
                           .compare(this.getKeyId(), that.getKeyId())
-                          .compare(this.getKey(), that.getKey())
+                          .compare(new String(this.getKey(), latin1), new String(that.getKey(), latin1))
                           .compare(this.getAlgorithm(), that.getAlgorithm())
                           .result();
   }
@@ -177,7 +181,7 @@ public final class HawkCredentials implements Comparable<HawkCredentials>
   public static class Builder
   {
     private String keyId;
-    private String key;
+    private byte[] key;
     private Algorithm algorithm;
 
     /**
@@ -222,6 +226,18 @@ public final class HawkCredentials implements Comparable<HawkCredentials>
      * @return the builder
      */
     public Builder key(final String key)
+    {
+      return this.key(key != null ? key.getBytes(utf8) : null);
+    }
+
+    /**
+     * Set the key.
+     *
+     * @param key
+     *          the key
+     * @return the builder
+     */
+    public Builder key(final byte[] key)
     {
       this.key = key;
       return this;

--- a/hawk-core/src/test/java/test/com/wealdtech/hawk/HawkCredentialsTest.java
+++ b/hawk-core/src/test/java/test/com/wealdtech/hawk/HawkCredentialsTest.java
@@ -35,7 +35,7 @@ public class HawkCredentialsTest
                                                        .algorithm(HawkCredentials.Algorithm.SHA256)
                                                        .build();
     assertEquals(testhc1.getKeyId(), "testkeyid");
-    assertEquals(testhc1.getKey(), "testkey");
+    assertEquals(testhc1.getKey(), "testkey".getBytes());
     assertEquals(testhc1.getAlgorithm().toString(), "sha256");
     testhc1.toString();
     testhc1.hashCode();
@@ -44,7 +44,7 @@ public class HawkCredentialsTest
 
     final HawkCredentials testhc2 = new HawkCredentials.Builder(testhc1).keyId("testkeyid2").build();
     assertEquals(testhc2.getKeyId(), "testkeyid2");
-    assertEquals(testhc1.getKey(), "testkey");
+    assertEquals(testhc1.getKey(), "testkey".getBytes());
     assertEquals(testhc1.getAlgorithm().toString(), "sha256");
     testhc2.toString();
     testhc2.hashCode();
@@ -74,7 +74,7 @@ public class HawkCredentialsTest
   {
     try
     {
-      new HawkCredentials.Builder().keyId("testkeyid").key(null).algorithm(HawkCredentials.Algorithm.SHA256).build();
+      new HawkCredentials.Builder().keyId("testkeyid").key((String) null).algorithm(HawkCredentials.Algorithm.SHA256).build();
       // Should not reach here
       fail();
     }


### PR DESCRIPTION
This PR adds support for `byte[]` keys. The reference (JavaScript) implementation of Hawk supports fully binary keys and not just ASCII/UTF-8-representable keys.